### PR TITLE
bump versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ setup(name="pipelinewise-target-redshift",
       install_requires=[
           'pipelinewise-singer-python==1.*',
           'boto3==1.12.39',
-          'psycopg2-binary==2.8.5',
+          'psycopg2-binary==2.9.5',
           'inflection==0.4.0',
-          'joblib==0.16.0'
+          'joblib==1.11.0'
       ],
       extras_require={
           "test": [


### PR DESCRIPTION
## Changes
- Resolving `psycopg-binary` incompatibility with newer versions of Python
- Bumping `joblib` to 1.11.0 to avoid security issues